### PR TITLE
feat(passageiro): cadastro de passageiro (RF-05)

### DIFF
--- a/POM.xml
+++ b/POM.xml
@@ -21,6 +21,18 @@
             <version>5.11.4</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.11.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>5.11.4</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/br/com/ciaaerea/Program.java
+++ b/src/main/java/br/com/ciaaerea/Program.java
@@ -80,11 +80,11 @@ public class Program {
         mainMenu.addOption(
                 new MenuOption("Passageiro", MenuOptionType.CADASTRAR, () -> {
                     System.out.print("Digite o CPF: ");
-                    String cpf = ConsoleInput.waitUserString();
+                    String cpf = ConsoleInput.waitUserString(true);
                     System.out.print("Digite o nome: ");
-                    String nome = ConsoleInput.waitUserString();
+                    String nome = ConsoleInput.waitUserString(true);
                     System.out.print("Digite um documento válido: ");
-                    String documento = ConsoleInput.waitUserString();
+                    String documento = ConsoleInput.waitUserString(true);
 
                     Passageiro passageiro = new Passageiro(nome, cpf, documento);
 

--- a/src/main/java/br/com/ciaaerea/Program.java
+++ b/src/main/java/br/com/ciaaerea/Program.java
@@ -5,13 +5,11 @@ import br.com.ciaaerea.UI.MenuOption;
 import br.com.ciaaerea.UI.MenuOptionType;
 import br.com.ciaaerea.UI.ConsoleInput;
 import br.com.ciaaerea.domain.model.Aeronave;
+import br.com.ciaaerea.domain.model.Passageiro;
 import br.com.ciaaerea.domain.model.Rota;
 import br.com.ciaaerea.domain.model.Voo;
 import br.com.ciaaerea.repositories.Repository;
-import br.com.ciaaerea.repositories.inMemory.AeronaveRepository;
-import br.com.ciaaerea.repositories.inMemory.RepositorySeed;
-import br.com.ciaaerea.repositories.inMemory.RotaRepository;
-import br.com.ciaaerea.repositories.inMemory.VooRepository;
+import br.com.ciaaerea.repositories.inMemory.*;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -20,6 +18,7 @@ public class Program {
     private static Repository<Rota> rotaRepo = new RotaRepository();
     private static Repository<Aeronave> aeronaveRepo = new AeronaveRepository();
     private static Repository<Voo> vooRepo = new VooRepository();
+    private static Repository<Passageiro> passRepo = new PassageiroRepository();
 
     public static void main(String[] args) {
         RepositorySeed.seed(rotaRepo, aeronaveRepo, vooRepo);
@@ -76,6 +75,20 @@ public class Program {
                     Voo voo = new Voo(aeronave, rota);
 
                     vooRepo.add(voo);
+                })
+        );
+        mainMenu.addOption(
+                new MenuOption("Passageiro", MenuOptionType.CADASTRAR, () -> {
+                    System.out.print("Digite o CPF: ");
+                    String cpf = ConsoleInput.waitUserString();
+                    System.out.print("Digite o nome: ");
+                    String nome = ConsoleInput.waitUserString();
+                    System.out.print("Digite um documento válido: ");
+                    String documento = ConsoleInput.waitUserString();
+
+                    Passageiro passageiro = new Passageiro(nome, cpf, documento);
+
+                    passRepo.add(passageiro);
                 })
         );
         mainMenu.addOption(

--- a/src/main/java/br/com/ciaaerea/UI/ConsoleInput.java
+++ b/src/main/java/br/com/ciaaerea/UI/ConsoleInput.java
@@ -10,6 +10,20 @@ public class ConsoleInput {
         return scan.nextLine().trim();
     }
 
+    public static String waitUserString(boolean validateNotBlank) {
+        while(true){
+            try {
+                String input = scan.nextLine().trim();
+                if (validateNotBlank && (input.isBlank())) {
+                    throw new IllegalArgumentException("Não esperado texto em branco");
+                }
+                return input;
+            }catch (IllegalArgumentException e){
+                System.out.println(e.getMessage());
+            }
+        }
+    }
+
     public static int waitUserInteger(int min, int max) {
         if (min >= max) throw new IllegalArgumentException("Limite mínimo não deve ser maior que máximo");
 

--- a/src/main/java/br/com/ciaaerea/UI/Menu.java
+++ b/src/main/java/br/com/ciaaerea/UI/Menu.java
@@ -1,5 +1,7 @@
 package br.com.ciaaerea.UI;
 
+import br.com.ciaaerea.domain.exceptions.BussinesViolationException;
+
 import java.util.*;
 
 public class Menu {
@@ -29,7 +31,12 @@ public class Menu {
             System.out.print("-----> ");
             MenuOption chosedOption = options.get(ConsoleInput.waitUserInteger(1, options.size())-1);
             ConsoleOptions.clearConsole();
-            chosedOption.run();
+            try {
+                chosedOption.run();
+            } catch (BussinesViolationException e) {
+                System.err.printf("VIOLAÇÃO DE REGRA: %s\n",e.getMessage());
+                ConsoleInput.waitUserEnter();
+            }
             lastOption = chosedOption;
         } while (!isExit(lastOption));
     }

--- a/src/main/java/br/com/ciaaerea/domain/exceptions/BussinesViolationException.java
+++ b/src/main/java/br/com/ciaaerea/domain/exceptions/BussinesViolationException.java
@@ -1,0 +1,7 @@
+package br.com.ciaaerea.domain.exceptions;
+
+public class BussinesViolationException extends RuntimeException{
+    public BussinesViolationException(String message){
+        super(message);
+    }
+}

--- a/src/main/java/br/com/ciaaerea/domain/model/Passageiro.java
+++ b/src/main/java/br/com/ciaaerea/domain/model/Passageiro.java
@@ -1,5 +1,7 @@
 package br.com.ciaaerea.domain.model;
 
+import br.com.ciaaerea.domain.exceptions.BussinesViolationException;
+
 public final class Passageiro extends Pessoa{
     private final String cpf;
     private String documento;
@@ -13,7 +15,7 @@ public final class Passageiro extends Pessoa{
 
     private void validarCPF(String cpf) {
         if (cpf == null || cpf.length() != 11){
-            throw new IllegalArgumentException("CPF inválido");
+            throw new BussinesViolationException("CPF deve ter 11 caracteres");
         }
     }
 

--- a/src/main/java/br/com/ciaaerea/domain/model/Passageiro.java
+++ b/src/main/java/br/com/ciaaerea/domain/model/Passageiro.java
@@ -6,8 +6,15 @@ public final class Passageiro extends Pessoa{
 
     public Passageiro(String nome, String cpf, String documento){
         super(nome);
+        validarCPF(cpf);
         this.cpf = cpf;
         this.documento = documento;
+    }
+
+    private void validarCPF(String cpf) {
+        if (cpf == null || cpf.length() != 11){
+            throw new IllegalArgumentException("CPF inválido");
+        }
     }
 
     public String getCpf() {

--- a/src/main/java/br/com/ciaaerea/domain/model/Passageiro.java
+++ b/src/main/java/br/com/ciaaerea/domain/model/Passageiro.java
@@ -9,8 +9,15 @@ public final class Passageiro extends Pessoa{
     public Passageiro(String nome, String cpf, String documento){
         super(nome);
         validarCPF(cpf);
+        validarDocumento(documento);
         this.cpf = cpf;
         this.documento = documento;
+    }
+
+    private void validarDocumento(String documento) {
+        if (documento == null || documento.isBlank()){
+            throw new BussinesViolationException("Documento não pode estar em branco");
+        }
     }
 
     private void validarCPF(String cpf) {

--- a/src/main/java/br/com/ciaaerea/domain/model/Pessoa.java
+++ b/src/main/java/br/com/ciaaerea/domain/model/Pessoa.java
@@ -1,5 +1,7 @@
 package br.com.ciaaerea.domain.model;
 
+import br.com.ciaaerea.domain.exceptions.BussinesViolationException;
+
 public abstract class Pessoa {
     protected String nome;
 
@@ -10,7 +12,7 @@ public abstract class Pessoa {
 
     private void validarNome(String nome) {
         if (nome == null || nome.isBlank()) {
-            throw new IllegalArgumentException("Nome do passageiro não pode estar em branco");
+            throw new BussinesViolationException("Nome do passageiro não pode estar em branco");
         }
     }
 

--- a/src/main/java/br/com/ciaaerea/domain/model/Pessoa.java
+++ b/src/main/java/br/com/ciaaerea/domain/model/Pessoa.java
@@ -2,10 +2,19 @@ package br.com.ciaaerea.domain.model;
 
 public abstract class Pessoa {
     protected String nome;
-    protected Pessoa(String nome){
+
+    protected Pessoa(String nome) {
+        validarNome(nome);
         this.nome = nome;
     }
-    public String getNome(){
+
+    private void validarNome(String nome) {
+        if (nome == null || nome.isBlank()) {
+            throw new IllegalArgumentException("Nome do passageiro não pode estar em branco");
+        }
+    }
+
+    public String getNome() {
         return this.nome;
     }
 }

--- a/src/main/java/br/com/ciaaerea/repositories/inMemory/InMemoryRepository.java
+++ b/src/main/java/br/com/ciaaerea/repositories/inMemory/InMemoryRepository.java
@@ -1,0 +1,26 @@
+package br.com.ciaaerea.repositories.inMemory;
+
+import br.com.ciaaerea.domain.model.Aeronave;
+import br.com.ciaaerea.repositories.Repository;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public abstract class InMemoryRepository <T> implements Repository<T> {
+    List<T> list = new ArrayList<>();
+
+    @Override
+    public void add(T T) {
+        list.add(T);
+    }
+
+    @Override
+    public List<T> findAll() {
+        return new ArrayList<>(list);
+    }
+
+    @Override
+    public T findByIndex(int index) {
+        return list.get(index);
+    }
+}

--- a/src/main/java/br/com/ciaaerea/repositories/inMemory/PassageiroRepository.java
+++ b/src/main/java/br/com/ciaaerea/repositories/inMemory/PassageiroRepository.java
@@ -1,10 +1,11 @@
 package br.com.ciaaerea.repositories.inMemory;
 
 import br.com.ciaaerea.domain.model.Aeronave;
+import br.com.ciaaerea.domain.model.Passageiro;
 import br.com.ciaaerea.repositories.Repository;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public class AeronaveRepository extends InMemoryRepository<Aeronave> {
+public final class PassageiroRepository extends InMemoryRepository<Passageiro> {
 }

--- a/src/main/java/br/com/ciaaerea/repositories/inMemory/RotaRepository.java
+++ b/src/main/java/br/com/ciaaerea/repositories/inMemory/RotaRepository.java
@@ -7,22 +7,5 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-public class RotaRepository implements Repository<Rota> {
-
-    List<Rota> rotas = new ArrayList<>();
-
-    @Override
-    public void add(Rota rota) {
-        rotas.add(rota);
-    }
-
-    @Override
-    public List<Rota> findAll() {
-        return new ArrayList<>(rotas);
-    }
-
-    @Override
-    public Rota findByIndex(int index) {
-        return rotas.get(index);
-    }
+public final class RotaRepository extends InMemoryRepository<Rota> {
 }

--- a/src/main/java/br/com/ciaaerea/repositories/inMemory/VooRepository.java
+++ b/src/main/java/br/com/ciaaerea/repositories/inMemory/VooRepository.java
@@ -5,22 +5,5 @@ import br.com.ciaaerea.repositories.Repository;
 import java.util.ArrayList;
 import java.util.List;
 
-public class VooRepository implements Repository<Voo> {
-
-    List<Voo> voos = new ArrayList<>();
-
-    @Override
-    public void add(Voo Voo) {
-        voos.add(Voo);
-    }
-
-    @Override
-    public List<Voo> findAll() {
-        return new ArrayList<>(voos);
-    }
-
-    @Override
-    public Voo findByIndex(int index) {
-        return voos.get(index);
-    }
+public final class VooRepository extends InMemoryRepository<Voo> {
 }

--- a/src/test/java/ciaaerea/domain/model/PassageiroTest.java
+++ b/src/test/java/ciaaerea/domain/model/PassageiroTest.java
@@ -1,0 +1,36 @@
+package ciaaerea.domain.model;
+
+import br.com.ciaaerea.domain.exceptions.BussinesViolationException;
+import br.com.ciaaerea.domain.model.Passageiro;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class PassageiroTest {
+    @ParameterizedTest
+    @CsvSource({
+        "Carlos,50301725802,5454545411",
+        "João,23126845665,6545252155",
+        "Jeferson,02325556898,4445445445"
+    })
+    public void dadoInformacoesCorretasQuandoInstaciarNaoDeveLancarExcecao(String nome, String cpf, String documento){
+        assertDoesNotThrow(()->{
+            new Passageiro(nome, cpf, documento);
+        });
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            ",50301725802,54545454",
+            "João,2312684566,6545252155",
+            "Jeferson,02325556898,"
+    })
+    public void dadasInformacoesIncorretasQuandoInstanciarDeveLancarExcecao(String nome, String cpf, String documento){
+        assertThrows(BussinesViolationException.class,()->{
+            new Passageiro(nome, cpf, documento);
+        });
+    }
+}

--- a/src/test/java/ciaaerea/domain/model/VooTest.java
+++ b/src/test/java/ciaaerea/domain/model/VooTest.java
@@ -11,7 +11,7 @@ public class VooTest {
         Rota rota = new Rota("EUA", "China");
         Aeronave aeronave = new Aeronave("Boeing 737", 215);
         Voo voo = new Voo(aeronave, rota);
-        Passageiro passageiro = new Passageiro("Eduardo Costa", "5231236802", "RG");
+        Passageiro passageiro = new Passageiro("Eduardo Costa", "52312368302", "RG");
         Reserva reserva = new Reserva(passageiro, voo);
         voo.getReservas().add(reserva);
 


### PR DESCRIPTION
**Descrição**

- Implementa de ponta a ponta cadastro de passageiro
- Abstrai lógica de persistência _In-Memory_ para classe abstrata
- Valida cpf (básico, por qtd. de char), e evita `NullPointerException`
- Cobre testes de _happy path_ e violações de regra de negócio

**Testes**
- Testes executados com sucesso (mvn test)